### PR TITLE
Factor out ID decode, disable debug

### DIFF
--- a/code.py
+++ b/code.py
@@ -1,10 +1,33 @@
 import board
+import time
 from supervisor import ticks_ms
 from time import sleep
 from digitalio import DigitalInOut, Pull
 from busio import I2C
 
 _TICKS_PERIOD = const(1<<29)
+
+# NCI protocol definitions
+
+# Header Message Type (MT) & Packet Boundary Flag (PBF)
+# byte 0, MSB nibble
+_HEADER_PBF_SEG_MASK     = const(0x10)
+_HEADER_MT_CTRL_DATA     = const(0x00)
+_HEADER_MT_CTRL_DATA_SEG = _HEADER_MT_CTRL_DATA &  _HEADER_PBF_SEG_MASK
+_HEADER_MT_CTRL_REQ      = const(0x20)
+_HEADER_MT_CTRL_REQ_SEG  = _HEADER_MT_CTRL_DATA & _HEADER_PBF_SEG_MASK
+_HEADER_MT_CTRL_RSP      = const(0x40)
+_HEADER_MT_CTRL_RSP_SEG  = _HEADER_MT_CTRL_RSP & _HEADER_PBF_SEG_MASK
+
+# Group Identifier (GID) for control packets
+# byte 0, LSB nibble
+_GID_CORE = const(0x00)
+_GID_RF   = const(0x01)
+
+# Opcode Identifier for control packets
+# byte 1, 6 LSBs
+_OID_RF_DISCOVER_MAP = const(0x00)
+_OID_RF_DISCOVER     = const(0x03)
 
 _STATUS_OK       = const(0x00)
 _STATUS_REJECTED = const(0x01)
@@ -74,9 +97,23 @@ def dump_package(buf: bytes, end: int, prefix: str = ""):
             , buf[5], " (PROTOCOL_T2T)"            if buf[5] == 0x02 else ""
             , buf[6], " (NFC_A_PASSIVE_POLL_MODE)" if buf[6] == 0x00 else ""
             , buf[7], buf[8], buf[9]))
-        for i in range(buf[9]):
-            print("{}RF_INTF_ACTIVATED_NTF({}) RFTS[{:02}]: {}".format(prefix, end, i, buf[2+7+i+1]))
-        de_offset=2+7+buf[9]+1
+        rtfs_length = buf[9]
+        rfts_offset = 9+1
+        # dump raw rfts
+        for i in range(rtfs_length):
+            print("{}RF_INTF_ACTIVATED_NTF({}) RFTS[{:02}]: {}".format(prefix, end, i, buf[rfts_offset+i]))
+        # decode NFCID1 of rfts for NFC_A_PASSIVE_POLL_MODE
+        if buf[6] == 0x00:
+            nfcid1_length = buf[rfts_offset+2]
+            print("  NFCID1 Length: {}".format(nfcid1_length))
+            if nfcid1_length > 0:
+                print("  NFCID1: ",end="")
+                for id_byte_offset in range(nfcid1_length):
+                    id_byte = "{}{:02x}".format(":" if id_byte_offset>0 else "", buf[rfts_offset+3+id_byte_offset])
+                    print(id_byte, end="")
+                print("")
+        # dump DE
+        de_offset = 9+rtfs_length+1
         print("{}RF_INTF_ACTIVATED_NTF({}) DE Mode: {} DE TX rate: {} DE RX rate: {} DE Act. Params: {}".format(prefix, end, buf[de_offset], buf[de_offset+1], buf[de_offset+2], buf[de_offset+3]))
     elif fst == 0x2f and snd == 0x02:
         print("{}PROPRIETARY_ACT_CMD({})".format(prefix, end))
@@ -152,7 +189,6 @@ class PN7150:
         if (end < 6 or self._buf[0] != 0x40 or self._buf[1] != 0x00
                 or self._buf[3] != _STATUS_OK or self._buf[5] != 0x01):
             return False
-
         self._write(NCI_CORE_INIT_CMD)
         end = self._read()
         if end < 20 or self._buf[0] != 0x40 or self._buf[1] != 0x01 or self._buf[3] != _STATUS_OK:
@@ -185,14 +221,14 @@ class PN7150:
         self._write(NCI_RF_DISCOVER_MAP_RW)
         end = self._read(10)
         self._i2c.unlock()
-        return end >= 4 and self._buf[0] == 0x41 and self._buf[1] == 0x00 and self._buf[3] == _STATUS_OK
+        return end >= 4 and (self._buf[0] & 0xf0) == _HEADER_MT_CTRL_RSP and (self._buf[0] & 0x0f) == _GID_RF and self._buf[1] == _OID_RF_DISCOVER_MAP and self._buf[3] == _STATUS_OK
 
     def startDiscoveryRW(self):
         assert self._i2c.try_lock()
         self._write(NCI_RF_DISCOVER_CMD_RW)
         end = self._read()
         self._i2c.unlock()
-        return end >= 4 and self._buf[0] == 0x41 and self._buf[1] == 0x03 and self._buf[3] == _STATUS_OK 
+        return end >= 4 and (self._buf[0] & 0xf0) == _HEADER_MT_CTRL_RSP and (self._buf[0] & 0x0f) == _GID_RF and self._buf[1] == _OID_RF_DISCOVER and (self._buf[3] == _STATUS_OK)
 
     def waitForDiscovery(self):
         assert self._i2c.try_lock()
@@ -200,7 +236,7 @@ class PN7150:
         while end == 0:
             end = self._read()
         self._i2c.unlock()
-        return True
+        return end
 
 class NT3H2:
     def __init__(self, i2c: I2C, addr: int = 0x55):
@@ -241,15 +277,18 @@ if __name__ == '__main__':
 
         nfc = PN7150(i2c, board.IRQ, board.VEN, debug=True)
 
-        assert nfc.connect()
-        print("Connected.")
+        while True:
+            print("\n------ Initiating NFC discovery ------")
+            assert nfc.connect()
+            print("Connected.")
 
-        assert nfc.modeRW()
-        print("Switched to read/write mode.")
+            assert nfc.modeRW()
+            print("Switched to read/write mode.")
 
-        assert nfc.startDiscoveryRW()
-        print("Started read/write discovery.")
+            assert nfc.startDiscoveryRW()
+            print("Started read/write discovery.")
 
-        nfc.waitForDiscovery()
+            nfc.waitForDiscovery()
+            time.sleep(2)
     finally:
         i2c.deinit()


### PR DESCRIPTION
    Factor out ID decode from dump_package(), disable debug
    
    * decode ID also in no-debug
    * add friendly output in no-debug
    * add some error handling for unsupported/erroneous ID
    * disable version dumps and main loop states in no-debug
    * decrease sleep to 1 second

Output example of two successful reads, one failed in no-debug mode:
```
------ Waiting for NFC tag proximity ------
Saw NFC tag with ID: 04:4b:19:f2:a1:13:90

------ Waiting for NFC tag proximity ------
Saw NFC tag with ID: 04:4b:19:f2:a1:13:90

------ Waiting for NFC tag proximity ------
Error decoding NFC tag ID: unsupported RF Technology and Mode 0x9f

------ Waiting for NFC tag proximity ------
```